### PR TITLE
Fixed bug in exitDataMode

### DIFF
--- a/common/short_range/src/u_short_range.c
+++ b/common/short_range/src/u_short_range.c
@@ -267,7 +267,7 @@ static void exitDataMode(const uShortRangePrivateInstance_t *pInstance)
             uPortTaskBlock(1100);
             uShortRangeEdmStreamAtWrite(pInstance->streamHandle, escSeq, 3);
         }
-    } else if (pInstance->mode == U_SHORT_RANGE_MODE_EDM) {
+    } else if (pInstance->mode == U_SHORT_RANGE_MODE_DATA) {
         if (uPortUartWrite(pInstance->streamHandle, escSeq, 3) != 3) {
             uPortTaskBlock(1100);
             uPortUartWrite(pInstance->streamHandle, escSeq, 3);


### PR DESCRIPTION
The function exitDataMode contained an error - the else if had exactly the same condition as the if, so if one was useing the normal data mode, exitDataMode was useless.

Test: *