### PR TITLE
Cellular optional change only: AT+CMEE=1

### DIFF
--- a/cell/src/u_cell_pwr.c
+++ b/cell/src/u_cell_pwr.c
@@ -73,7 +73,21 @@
  * during configuration.
  */
 static const char *const gpConfigCommand[] = {"ATE0",      // Echo off
-                                              "AT+CMEE=2", // Extended errors on
+#ifdef U_CFG_CELL_ENABLE_NUMERIC_ERROR
+// With this compilation flag defined numeric errors will be
+// returned and so uAtClientDeviceErrorGet() will be able
+// to return a non-zero value for deviceError.code.
+// IMPORTANT: this switch is simply for customer convenience,
+// no ubxlib code should set it or depend on the value
+// of deviceError.code.
+                                              "AT+CMEE=1", // Extended errors on, numeric format
+#else
+// The normal case: errors are reported by the module as
+// verbose text, most useful when debugging normally with
+// AT interface prints shown, uAtClientPrintAtSet() set
+// to true.
+                                              "AT+CMEE=2", // Extended errors on, verbose/text format
+#endif
                                               "ATI9",      // Firmware version
                                               "AT&C1",     // DCD circuit (109) changes with the carrier
                                               "AT&D0"      // Ignore changes to DTR


### PR DESCRIPTION
By default extended errors, `AT+CMEE`, is set to 2 to get the textual description of the error from the module, which is most beneficial when developing with the AT interface prints switched on.  However, this then necessarily omits the numeric error and so `uAtClientDeviceErrorGet()` can only return zero for `deviceError`.  This commit introduces a compilation flag, `U_CFG_CELL_ENABLE_NUMERIC_ERROR`: if this is defined `AT+CMEE` is set to 1 to obtain numeric errors only.