### PR TITLE
Fix the hex to bin conversion in hex mode reading

### DIFF
--- a/cell/src/u_cell_sock.c
+++ b/cell/src/u_cell_sock.c
@@ -1706,7 +1706,7 @@ int32_t uCellSockRead(uDeviceHandle_t cellHandle,
                                                                      thisActualReceiveSize * 2 + 1,
                                                                      false);
                                     if (readLength > 0) {
-                                        x = ((int32_t) dataSizeBytes - totalReceivedSize) * 2;
+                                        x = ((int32_t) dataSizeBytes) * 2;
                                         if (readLength > x) {
                                             readLength = x;
                                         }


### PR DESCRIPTION
dataSizeBytes is already adjusted together with totalReceivedSize, resulting in a too small value for x.
The consequence of this issue is that blocks of bytes at the end of long reads are replaced by zeroes.