### PR TITLE
Improve data throughput for POST and PUT by reducing chunk length when using UART

### DIFF
--- a/common/http_client/src/u_http_client.c
+++ b/common/http_client/src/u_http_client.c
@@ -110,7 +110,7 @@
  * can probably increase this, but bear in mind that the
  * cellular module can only write to flash so fast.
  */
-# define U_HTTP_CLIENT_CELL_FILE_CHUNK_LENGTH 1024
+# define U_HTTP_CLIENT_CELL_FILE_CHUNK_LENGTH 100
 #endif
 
 /** The maximum length of the first line of an HTTP response.


### PR DESCRIPTION
This pull request aims to improve the performance of POST and PUT data uploads by reducing the chunk length. By decreasing the chunk size from 1024 to 100, we observed the following speed-up:

- CHUNK_LENGTH = 1024: 1.2 MBit/s
- CHUNK_LENGTH = 100: **1.5** MBit/s

We conducted the measurement using a UART baudrate of 3M.