### PR TITLE
Add user context to device handle

### DIFF
--- a/common/device/api/u_device.h
+++ b/common/device/api/u_device.h
@@ -428,6 +428,24 @@ int32_t uDeviceOpen(const uDeviceCfg_t *pDeviceCfg,
  */
 int32_t uDeviceClose(uDeviceHandle_t devHandle, bool powerOff);
 
+/** Attach user context to device.
+ *
+ * Note: This is NOT thread-safe and should NOT be called when any
+ * other uDevice API function might be called.  Best call it just
+ * after calling uDeviceOpen() and before calling anything else.
+ *
+ *
+ * @param devHandle    handle to a previously opened device.
+ * @param pUserContext a user context to set.
+ */
+void uDeviceSetUserContext(uDeviceHandle_t devHandle, void *pUserContext);
+
+/** Get device attached user context.
+ *
+ * @return User context that was set using uDeviceSetUserContext().
+ */
+void *pUDeviceGetUserContext(uDeviceHandle_t devHandle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/common/device/src/u_device.c
+++ b/common/device/src/u_device.c
@@ -346,4 +346,24 @@ int32_t uDeviceClose(uDeviceHandle_t devHandle, bool powerOff)
     return errorCode;
 }
 
+void uDeviceSetUserContext(uDeviceHandle_t devHandle, void *pUserContext)
+{
+    if (devHandle != NULL) {
+        U_DEVICE_INSTANCE(devHandle)->pUserContext = pUserContext;
+    }
+}
+
+/** Get device attached user context.
+ *
+ * @return User context that was set using @ref uDeviceSetUserContext.
+ */
+void *pUDeviceGetUserContext(uDeviceHandle_t devHandle)
+{
+    if (devHandle == NULL) {
+        return NULL;
+    } else {
+        return U_DEVICE_INSTANCE(devHandle)->pUserContext;
+    }
+}
+
 // End of file

--- a/common/device/src/u_device_shared.h
+++ b/common/device/src/u_device_shared.h
@@ -83,6 +83,7 @@ typedef struct {
     uDeviceType_t deviceType;   /**< type of device. */
     int32_t moduleType;         /**< module identification (when applicable). */
     void *pContext;             /**< private instance data for the device. */
+    void *pUserContext;         /**< user context attached to device. */
     uDeviceNetworkData_t networkData[U_DEVICE_NETWORKS_MAX_NUM]; /**< network cfg and private data. */
     // Note: In the future structs of function pointers for socket, MQTT etc.
     // implementations may be added here.


### PR DESCRIPTION
Global variables should be avoided, each callback registration should have a user context argument to be passed to the callback when invoked.

There are callbacks that do not have a user context argument, uGnssPosGetStreamedStart is an example.

This change introduces the ability to attach a user context to the device handle, it will allow singleton callbacks such as uGnssPosGetStreamedStart to be able to extract the context without refactoring the registration functions and the callback signatures.

```c
    void *context = "A";
    if (uDeviceOpen(&gDeviceCfg, &device_handle) == 0) {
        uDeviceSetUserContext(device_handle, context);
        assert(uDeviceGetUserContext(device_handle) == context);
    }
```