### PR TITLE
gnss: remove device from global list when no poweroff

### DIFF
--- a/common/device/src/u_device_private_gnss.c
+++ b/common/device/src/u_device_private_gnss.c
@@ -129,6 +129,7 @@ static int32_t removeDevice(uDeviceHandle_t devHandle, bool powerOff)
                 uPortFree(pContext);
             }
         } else {
+            uGnssRemove(devHandle);
             uPortFree(pContext);
         }
     }


### PR DESCRIPTION
The following code should be valid to recover from a situation in which the GNSS is disconnected/connected or power up.

```c
  while((uret = uDeviceOpen(&gDeviceCfg,
          &device_handle)) != U_ERROR_COMMON_SUCCESS) {
  	uPortTaskBlock(5000);
  }
```

Current implementation fails with U_ERROR_COMMON_INVALID_PARAMETER with no recovery option, this loop is infinite connecting GNSS will have no affect.

The reason is that the removeDevice() is called with powerOff=false, this result in not removing the device from the global device list.

When the device is opened again it is already found within the list at by pGetGnssInstanceTransportHandle which is called by uGnssAdd(), uGnssAdd() returns U_ERROR_COMMON_INVALID_PARAMETER.

The software should release any resources attached to a device regardless of poweron/poweroff, the resources are logical and may be created when required.

This patch removes the device from the list in case of poweroff was not requested.