### PR TITLE
Gss memory management fixups

### DIFF
--- a/gnss/src/u_gnss_msg.c
+++ b/gnss/src/u_gnss_msg.c
@@ -355,6 +355,7 @@ int32_t uGnssMsgPrivateReceiveStart(uGnssPrivateInstance_t *pInstance,
                                 uPortMutexDelete(pMsgReceive->readerMutexHandle);
                             }
                             uPortFree(pInstance->pTemporaryBuffer);
+                            pInstance->pTemporaryBuffer = NULL;
                             uRingBufferGiveReadHandle(&(pInstance->ringBuffer),
                                                       pMsgReceive->ringBufferReadHandle);
                             uPortFree(pInstance->pMsgReceive);

--- a/gnss/src/u_gnss_pos.c
+++ b/gnss/src/u_gnss_pos.c
@@ -808,9 +808,9 @@ int32_t uGnssPosGetStreamedStart(uDeviceHandle_t gnssHandle,
                 pInstance->printUbxMessages = temp;
             }
         }
-    }
 
-    U_PORT_MUTEX_UNLOCK(gUGnssPrivateMutex);
+        U_PORT_MUTEX_UNLOCK(gUGnssPrivateMutex);
+    }
 
     return errorCode;
 }


### PR DESCRIPTION
Two commits:

* Fix for uGnssMsgPrivateReceiveStart: do not double free pInstance->pTemporaryBuffer
* Fix for uGnssPosGetStreamedStart: do not release NULL mutex