### PR TITLE
Fix for uGnssPosGetStreamedStart: Return zero on success

### DIFF
--- a/gnss/src/u_gnss_pos.c
+++ b/gnss/src/u_gnss_pos.c
@@ -795,6 +795,7 @@ int32_t uGnssPosGetStreamedStart(uDeviceHandle_t gnssHandle,
                             // And we're off
                             pStreamedPosition->gnssHandle = gnssHandle;
                             pStreamedPosition->asyncHandle = errorCode;
+                            errorCode = 0;
                         } else {
                             // If we couldn't create the asynchronous
                             // message receiver, clean up


### PR DESCRIPTION
per documentation zero should be returned when success while nested uGnssMsgPrivateReceiveStart returns a handle.

```
 * @return               zero on success or negative error code on
 *                       failure.
```