### PR TITLE
Improvements for newer Zephyr versions

### DIFF
--- a/port/platform/common/debug_utils/src/arch/arm/u_sections_zephyr.h
+++ b/port/platform/common/debug_utils/src/arch/arm/u_sections_zephyr.h
@@ -17,8 +17,14 @@
 #ifndef _U_SECTIONS_ZEPHYR_H_
 #define _U_SECTIONS_ZEPHYR_H_
 
+#include <version.h>
+
 /* No other #includes allowed here. */
-#include "linker/linker-defs.h"
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/linker/linker-defs.h>
+#else
+#include <linker/linker-defs.h>
+#endif
 
 /** @file
  * @brief This file is internally used to map Zephyr linker sections.

--- a/port/platform/common/debug_utils/src/zephyr/u_dump_threads.c
+++ b/port/platform/common/debug_utils/src/zephyr/u_dump_threads.c
@@ -17,7 +17,14 @@
 /** @file
  * @brief Thread dumper for Zephyr.
  */
-#include "kernel.h"
+
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/kernel.h>
+#else
+#include <kernel.h>
+#endif
 
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS

--- a/port/platform/zephyr/CMakeLists.txt
+++ b/port/platform/zephyr/CMakeLists.txt
@@ -78,7 +78,7 @@ zephyr_include_directories(
     cfg
     src
     ${UBXLIB_BASE}/port/clib
-    ${ZEPHYR_BASE}/include/zephyr
+    ${ZEPHYR_BASE}/include
 )
 
 # Add any compile options that came out of ubxlib.cmake

--- a/port/platform/zephyr/app/u_main.c
+++ b/port/platform/zephyr/app/u_main.c
@@ -42,7 +42,13 @@
 #include "u_port_debug.h"
 #include "u_port_os.h"
 
-#include "kernel.h"
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/kernel.h>
+#else
+#include <kernel.h>
+#endif
 
 #ifdef CONFIG_ARCH_POSIX
 #include "posix_board_if.h"

--- a/port/platform/zephyr/cfg/u_cfg_app_platform_specific.h
+++ b/port/platform/zephyr/cfg/u_cfg_app_platform_specific.h
@@ -17,14 +17,18 @@
 #ifndef _U_CFG_APP_PLATFORM_SPECIFIC_H_
 #define _U_CFG_APP_PLATFORM_SPECIFIC_H_
 
+/* This inclusion is required to get the Zephyr version.
+ */
+#include <version.h>
+
 /* This inclusion is required to get the UART CTS/RTS pin assignments
  * from the Zephyr device tree.
  */
-#include "devicetree.h"
-
-/* This inclusion is required to get the Zephyr version.
- */
-#include "version.h"
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/devicetree.h>
+#else
+#include <devicetree.h>
+#endif
 
 /** @file
  * @brief This header file contains configuration information for

--- a/port/platform/zephyr/cfg/u_cfg_test_platform_specific.h
+++ b/port/platform/zephyr/cfg/u_cfg_test_platform_specific.h
@@ -26,10 +26,14 @@
  * for the module is likely different to that from the MCU: check the
  * data sheet for the module to determine the mapping.
  */
-#include "devicetree.h"
+#include <version.h> // For KERNEL_VERSION_MAJOR
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/devicetree.h>
+#else
+#include <devicetree.h>
+#endif
 #include "u_runner.h"
 #include "u_port_clib_platform_specific.h" // For rand
-#include "version.h" // For KERNEL_VERSION_MAJOR
 
 /** @file
  * @brief Porting layer and configuration items passed in at application

--- a/port/platform/zephyr/src/u_port.c
+++ b/port/platform/zephyr/src/u_port.c
@@ -42,8 +42,15 @@
 #include "u_port_event_queue_private.h"
 #include "u_port_private.h"
 
-#include "kernel.h"
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#else
+#include <kernel.h>
 #include <device.h>
+#endif
 
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS

--- a/port/platform/zephyr/src/u_port.c
+++ b/port/platform/zephyr/src/u_port.c
@@ -189,9 +189,14 @@ int32_t uPortGetTimezoneOffsetSeconds()
     return offset;
 }
 
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,4,0)
+static int ubxlib_preinit(void)
+{
+#else
 static int ubxlib_preinit(const struct device *arg)
 {
     ARG_UNUSED(arg);
+#endif
 
     k_thread_system_pool_assign(k_current_get());
     return 0;

--- a/port/platform/zephyr/src/u_port_clib.c
+++ b/port/platform/zephyr/src/u_port_clib.c
@@ -27,7 +27,11 @@
 #include <version.h>
 
 #if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,5,0)
+#include <zephyr/random/random.h>
+#else
 #include <zephyr/random/rand32.h>
+#endif
 #else
 #include <random/rand32.h>
 #endif

--- a/port/platform/zephyr/src/u_port_clib.c
+++ b/port/platform/zephyr/src/u_port_clib.c
@@ -24,7 +24,14 @@
 # include "u_cfg_override.h" // For a customer's configuration override
 #endif
 
-#include "random/rand32.h"
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/random/rand32.h>
+#else
+#include <random/rand32.h>
+#endif
+
 #include "string.h"
 
 #include "u_assert.h"

--- a/port/platform/zephyr/src/u_port_debug.c
+++ b/port/platform/zephyr/src/u_port_debug.c
@@ -33,7 +33,13 @@
 
 #include "u_error_common.h"
 
-#include "sys/printk.h"
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/sys/printk.h>
+#else
+#include <sys/printk.h>
+#endif
 
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS

--- a/port/platform/zephyr/src/u_port_gatt.c
+++ b/port/platform/zephyr/src/u_port_gatt.c
@@ -24,10 +24,18 @@
 
 #ifdef CONFIG_BT
 
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#else
 #include <zephyr/types.h>
 #include <kernel.h>
-
 #include <device.h>
+#endif
+
 #include <soc.h>
 
 #include "stddef.h"    // NULL, size_t etc.
@@ -44,9 +52,15 @@
 #include "u_port_os.h"
 #include "u_port_event_queue.h"
 
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#else
 #include <bluetooth/conn.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
+#endif
 
 #include "string.h" // For memcpy()
 

--- a/port/platform/zephyr/src/u_port_gpio.c
+++ b/port/platform/zephyr/src/u_port_gpio.c
@@ -31,10 +31,17 @@
 #include "u_port_os.h"      // Needed by u_port_private.h
 #include "u_port_gpio.h"
 
-#include "kernel.h"
-#include "device.h"
-#include "drivers/gpio.h"
-#include "version.h"
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#else
+#include <kernel.h>
+#include <device.h>
+#include <drivers/gpio.h>
+#endif
 
 #include "u_port_private.h"  // Down here because it needs to know about the Zephyr device tree
 

--- a/port/platform/zephyr/src/u_port_i2c.c
+++ b/port/platform/zephyr/src/u_port_i2c.c
@@ -18,11 +18,20 @@
  * @brief Implementation of the port I2C API for the Zephyr platform.
  */
 
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
+#else
 #include <zephyr/types.h>
 #include <kernel.h>
-#include <drivers/i2c.h>
-
 #include <device.h>
+#include <drivers/i2c.h>
+#endif
+
 #include <soc.h>
 
 #include "stddef.h"
@@ -37,7 +46,6 @@
 #include "u_port_os.h"
 #include "u_cfg_os_platform_specific.h"
 #include "u_port_i2c.h"
-#include "version.h"
 
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS

--- a/port/platform/zephyr/src/u_port_os.c
+++ b/port/platform/zephyr/src/u_port_os.c
@@ -75,8 +75,15 @@
 #include "u_port.h"
 #include "u_port_os.h"
 
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#else
 #include <kernel.h>
-#include "device.h"
+#include <device.h>
+#endif
 
 #include "u_port_private.h"  // Down here because it needs to know about the Zephyr device tree
 

--- a/port/platform/zephyr/src/u_port_private.c
+++ b/port/platform/zephyr/src/u_port_private.c
@@ -33,10 +33,17 @@
 #include "u_port_heap.h"
 #include "u_port_event_queue.h"
 
-#include "kernel.h"
-#include "device.h"
-#include "drivers/gpio.h"
-#include "version.h"
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#else
+#include <kernel.h>
+#include <device.h>
+#include <drivers/gpio.h>
+#endif
 
 #include "u_port_private.h"  // Down here because it needs to know about the Zephyr device tree
 

--- a/port/platform/zephyr/src/u_port_spi.c
+++ b/port/platform/zephyr/src/u_port_spi.c
@@ -20,13 +20,24 @@
  * @brief Implementation of the port SPI API for the Zephyr platform.
  */
 
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/devicetree/spi.h>
+#else
 #include <zephyr/types.h>
 #include <kernel.h>
+#include <device.h>
 #include <drivers/spi.h>
 #include <drivers/gpio.h>
 #include <devicetree/spi.h>
+#endif
 
-#include <device.h>
 #include <soc.h>
 
 #include "stddef.h"
@@ -44,7 +55,6 @@
 #include "u_port_spi.h"
 #include "u_port_private.h"
 #include "u_cfg_os_platform_specific.h"
-#include "version.h"
 
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS

--- a/port/platform/zephyr/src/u_port_uart.c
+++ b/port/platform/zephyr/src/u_port_uart.c
@@ -26,11 +26,20 @@
 # include "u_cfg_override.h" // For a customer's configuration override
 #endif
 
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/types.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#else
 #include <zephyr/types.h>
 #include <kernel.h>
-#include <drivers/uart.h>
-
 #include <device.h>
+#include <drivers/uart.h>
+#endif
+
 #include <soc.h>
 
 #include "stddef.h"    // NULL, size_t etc.
@@ -50,7 +59,6 @@
 #include "u_port_os.h"
 #include "u_port_event_queue.h"
 #include "u_port_uart.h"
-#include "version.h"
 
 #include "string.h" // For memcpy()
 

--- a/port/test/u_port_test.c
+++ b/port/test/u_port_test.c
@@ -75,8 +75,13 @@
 
 #include "u_test_util_resource_check.h"
 
-#ifdef CONFIG_IRQ_OFFLOAD
-# include <irq_offload.h> // To test semaphore from ISR in zephyr
+#ifdef CONFIG_IRQ_OFFLOAD // To test semaphore from ISR in zephyr
+#include <version.h>
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/irq_offload.h>
+#else
+#include <irq_offload.h>
+#endif
 #endif
 
 /* ----------------------------------------------------------------

--- a/zephyr/test/u_main.c
+++ b/zephyr/test/u_main.c
@@ -26,7 +26,13 @@
 
 #include "u_cfg_app_platform_specific.h"
 
-#include "kernel.h"
+#include <version.h>
+
+#if KERNEL_VERSION_NUMBER >= ZEPHYR_VERSION(3,1,0)
+#include <zephyr/kernel.h>
+#else
+#include <kernel.h>
+#endif
 
 /* ----------------------------------------------------------------
  * COMPILE-TIME MACROS


### PR DESCRIPTION
This will respect changes to the Zephyr RTOS interfaces since v3.1

1. **since v3.1**: All Zephyr public headers have been moved to `include/zephyr`, meaning they need to be prefixed with `<zephyr/...>` when included.
2. **since v3.4**: `SYS_INIT` callback no longer requires a `device` argument. The new callback signature is `int f(void)`.
3. **since v3.5**: Random API header `<zephyr/random/rand32.h>` is deprecated in favor of `<zephyr/random/random.h>`. The old header will be removed in future releases and its usage should be avoided.