### PR TITLE
Suppress unnecessary GCC truncation warnings using compiler directives

### DIFF
--- a/cell/src/u_cell_cfg.c
+++ b/cell/src/u_cell_cfg.c
@@ -2181,6 +2181,8 @@ int64_t uCellCfgSetTime(uDeviceHandle_t cellHandle, int64_t timeLocal,
         // The format is "yy/MM/dd,hh:mm:ss+TZ" where +TZ is
         // in quarter hours.  First get the time in a struct
         if ((pInstance != NULL) && gmtime_r((const time_t *) &timeLocal, &tmStruct) != NULL) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
             int32_t ignored = snprintf(buffer, sizeof(buffer), "%02d/%02d/%02d,%02d:%02d:%02d%c%02d",
                                        tmStruct.tm_year % 100, tmStruct.tm_mon + 1, tmStruct.tm_mday,
                                        tmStruct.tm_hour, tmStruct.tm_min, tmStruct.tm_sec,
@@ -2188,6 +2190,7 @@ int64_t uCellCfgSetTime(uDeviceHandle_t cellHandle, int64_t timeLocal,
                                        timeZoneSeconds >= 0 ? (int) timeZoneSeconds / (15 * 60) : (int) - timeZoneSeconds / (15 * 60));
             // This to stop GCC 12.3.0 complaining that variables printed into buffer are being truncated
             (void) ignored;
+#pragma GCC diagnostic pop
             atHandle = pInstance->atHandle;
             uAtClientLock(atHandle);
             uAtClientCommandStart(atHandle, "AT+CCLK=");

--- a/common/at_client/src/u_at_client.c
+++ b/common/at_client/src/u_at_client.c
@@ -645,7 +645,7 @@ static char *pPrintTimestamp(const char *pPrefix, const char *pPostfix,
                                        (int) x, pPostfix);
             // This to stop GCC 12.3.0 complaining that variables printed into pBuffer are being truncated
             (void) ignored;
- #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
         }
     }
 

--- a/common/at_client/src/u_at_client.c
+++ b/common/at_client/src/u_at_client.c
@@ -636,6 +636,8 @@ static char *pPrintTimestamp(const char *pPrefix, const char *pPostfix,
             // Months counting from 1 instead of 0
             tmStruct.tm_mon++;
             x %= 1000;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
             int32_t ignored = snprintf(pBuffer, size, "%s%04d/%02d/%02d %02d:%02d:%02d.%03d%s",
                                        pPrefix, tmStruct.tm_year, tmStruct.tm_mon,
                                        tmStruct.tm_mday, tmStruct.tm_hour,
@@ -643,6 +645,7 @@ static char *pPrintTimestamp(const char *pPrefix, const char *pPostfix,
                                        (int) x, pPostfix);
             // This to stop GCC 12.3.0 complaining that variables printed into pBuffer are being truncated
             (void) ignored;
+ #pragma GCC diagnostic pop
         }
     }
 


### PR DESCRIPTION
#190 - Stop GCC from complaining in general about truncation issues using GCC compiler directives. This means that older GCC compilers will not get a warning. Tested on zephyr's eabi-gcc compiler which is on version 12.2

Unsure on whether or not we should remove the ignored variable and void cast now.