### PR TITLE
cell: Fix memory leak in case uAtClientUnlock returns failure

### DIFF
--- a/cell/src/u_cell_http.c
+++ b/cell/src/u_cell_http.c
@@ -628,6 +628,9 @@ int32_t uCellHttpOpen(uDeviceHandle_t cellHandle, const char *pServerName,
                                     // Free memory
                                     uPortFree(pHttpInstance);
                                 }
+                            } else {
+                                // Free memory
+                                uPortFree(pHttpInstance);
                             }
                         }
                         // Free temporary memory


### PR DESCRIPTION
In the case `uAtClientUnlock()` in `u_cell_http.c` returned a failure code, the memory for `pHttpInstance` was not released.

The issue appeared rarely in combination with bad cellular coverage (disconnect during transmission attempt). The log files in indicated a memory leak:
```
01.01.00 01:42:39.956 DBG WDG [pool] malloc 72B @0x20001708   > pContext
01.01.00 01:42:39.956 DBG WDG [pool] malloc 80B @0x20001758   > pContext->semaphoreHandle
01.01.00 01:42:39.956 DBG WDG [pool] malloc 4B @0x20000cf8    > pContext->pPriv
01.01.00 01:42:39.957 DBG WDG [pool] malloc 1025B @0x20007b18 > pServerNameTemp
01.01.00 01:42:39.957 DBG WDG [pool] malloc 276B @0x20003af8  > pHttpInstance -> never released!
// uAtClientUnlock() returned -10 in u_cell_http.c
01.01.00 01:42:40.100 DBG WDG [pool] free @0x20007b18         < pServerNameTemp
01.01.00 01:42:40.100 DBG WDG [pool] free @0x20000cf8         < pContext->pPriv
01.01.00 01:42:40.100 DBG WDG [pool] free @0x20001758         < pContext->semaphoreHandle
01.01.00 01:42:40.101 DBG WDG [pool] free @0x20001708         < pContext
```
